### PR TITLE
Load values from all the configuration files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,7 @@ class sysctl (
 
   exec { 'sysctl -p':
     subscribe   => File['sysctl.conf'],
+    command     => "cat $sysctl::config_file $sysctl::config_dir/*.conf | sysctl -p -",
     refreshonly => true,
     path        => '/sbin:/bin:/usr/sbin:/usr/bin',
   }


### PR DESCRIPTION
Hello,
as of know the module handles additional configuration files under /etc/sysctl.d but does not reload their values when installed - it's done only for sysctl.conf.

This patch - rather ugly, I know - allows to load all the changes done in configuration file when some of them is changed.

HTH,
Sandro
