### PR TITLE
Bugfix: resource.class.defaultprovider.ancestors.include breaks in spec ...

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -31,12 +31,7 @@ module Puppet
 
         newproperty(:target) do
             desc "Name of the file to store parameters in"
-            defaultto { if @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
-                            @resource.class.defaultprovider.default_target
-                        else
-                            nil
-                        end
-            }
+            defaultto { nil }
         end
     end
 end


### PR DESCRIPTION
For whatever reason, this code breaks in Puppet RSpec tests:

```
  Failure/Error: it { should compile.with_all_deps }
 NoMethodError:
   undefined method `ancestors' for nil:NilClass
 # ./modules/vendor/sysctl/lib/puppet/type/sysctl.rb:34:in `default'
```

Hard-setting the default to Nil seems to do the trick though.
