### PR TITLE
Updating params.pp to handle package name for CentOS 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,10 +16,13 @@ class sysctl::params {
 
   ### Application related parameters
 
-  $package = $::operatingsystem ? {
-    default => 'procps',
-  }
-
+#package name fix for centos 7
+  if $::operatingsystem == 'CentOS' and $::lsbmajdistrelease == '7' {
+    $package = 'procps-ng'
+  } else {
+    $package = 'procps'
+  } 
+  
   $config_dir = $::operatingsystem ? {
     default => '/etc/sysctl.d',
   }


### PR DESCRIPTION
Package name for CentOS 7 : procps-ng
For CentOS 6 and Debian : procps

This change works for me. May be it can be handled in other ways, but i am not that much an expert in code. Please take a look.