### PR TITLE
Fix for puppet 4

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -1,5 +1,4 @@
-module Puppet
-    newtype(:sysctl) do
+Puppet::Type.newtype(:sysctl) do
 
         @doc = "Manages kernel parameters in /etc/sysctl.conf.  By default this will
                 only edit the configuration file, and not change any of the runtime
@@ -39,5 +38,4 @@ module Puppet
                         end
             }
         end
-    end
 end

--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -1,41 +1,41 @@
 Puppet::Type.newtype(:sysctl) do
 
-        @doc = "Manages kernel parameters in /etc/sysctl.conf.  By default this will
-                only edit the configuration file, and not change any of the runtime
-                values.  If you wish changes to be activated right away, you can do
-                so with an exec like so:
+    @doc = "Manages kernel parameters in /etc/sysctl.conf.  By default this will
+            only edit the configuration file, and not change any of the runtime
+            values.  If you wish changes to be activated right away, you can do
+            so with an exec like so:
 
-                        exec { load-sysctl:
-                            command => \"/sbin/sysctl -p /etc/sysctl.conf\",
-                            refreshonly => true
-                        }
+                    exec { load-sysctl:
+                        command => \"/sbin/sysctl -p /etc/sysctl.conf\",
+                        refreshonly => true
+                    }
 
-                Set any changes you want to happen right away to notify this command,
-                or you can set it as the default:
+            Set any changes you want to happen right away to notify this command,
+            or you can set it as the default:
 
-                        Sysctl {
-                            notify => Exec[load-sysctl]
-                        }"
+                    Sysctl {
+                        notify => Exec[load-sysctl]
+                    }"
 
-        ensurable
+    ensurable
 
-        newparam(:name, :namevar => true) do
-            desc "Name of the parameter"
-            isnamevar
-        end
-        
-        newproperty(:val) do
-            desc "Value the parameter should be set to"
-        end
+    newparam(:name, :namevar => true) do
+        desc "Name of the parameter"
+        isnamevar
+    end
 
-        newproperty(:target) do
-            desc "Name of the file to store parameters in"
-            defaultto { if @resource.class.defaultprovider and
-                           @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
-                            @resource.class.defaultprovider.default_target
-                        else
-                            nil
-                        end
-            }
-        end
+    newproperty(:val) do
+        desc "Value the parameter should be set to"
+    end
+
+    newproperty(:target) do
+        desc "Name of the file to store parameters in"
+        defaultto { if @resource.class.defaultprovider and
+                       @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
+                        @resource.class.defaultprovider.default_target
+                    else
+                        nil
+                    end
+        }
+    end
 end


### PR DESCRIPTION
Fix deprecation notice about Puppet.newtype, occuring when using puppet 4.
See https://docs.puppetlabs.com/puppet/4.2/reference/deprecated_api.html#puppetnewtype 